### PR TITLE
Add bidirectional resource ↔ template context-menu navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- BEAR.Resource ↔ template navigation: jump between a resource class and its Twig/Qiq template from the editor and Project View context menus (`Open Template` / `Open Resource`); hidden when no counterpart exists, with a popup for multiple matches.
+- `#[Embed]` template navigation: Cmd+click a Twig/Qiq variable (`{{ embedded }}` / `{{= $this->embedded }}`) to open the embedded template, with a gutter icon on the matching line (#18).
 - Go to bound interceptor: bound Ray.Aop attributes (e.g. `#[Transactional]`) now show a BEAR gutter icon and can jump to interceptor class(es) bound in a module via `bindInterceptor()` from the icon or `Navigate > Go to Bound Interceptor` (#19). Standard PhpStorm declaration navigation remains available for the attribute class itself.
 - Incoming Link/Embed relation gutter: BEAR.Resource methods now show incoming static `#[Link]` / `#[Embed]` relations from other resources and navigate back to the source attribute declaration.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 * BEAR.Resource goto from URIs such as `app://self/user` to `src/Resource/App/User.php`
 * BEAR.Resource JSON Schema goto
 * Incoming Link/Embed relation gutter for BEAR.Resource methods
+* `#[Embed]` template navigation: Cmd+click a Twig/Qiq variable to open the embedded template
+* BEAR.Resource ↔ template navigation: jump between a resource class and its Twig/Qiq template from the context menu
 * Extract BEAR.Resource parameters to Ray.InputQuery DTO
 * Ray.Aop bound interceptor gutter icon and navigation from attributes such as `#[Transactional]`
 * Ray.MediaQuery SQL goto

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("junit:junit:4.13.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 
     intellijPlatform {
         phpstorm(properties("platformVersion"))

--- a/src/main/java/idea/bear/sunday/template/GoToTemplateOrResourceAction.java
+++ b/src/main/java/idea/bear/sunday/template/GoToTemplateOrResourceAction.java
@@ -1,0 +1,151 @@
+package idea.bear.sunday.template;
+
+import com.intellij.codeInsight.navigation.NavigationUtil;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.popup.JBPopup;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
+import idea.bear.sunday.BearSundayBundle;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Navigates between a BEAR.Resource class and its template (Twig or Qiq), in both directions,
+ * from the Project View and editor context menus. The label is "Open Template" on a resource
+ * file and "Open Resource" on a template; the item is hidden unless the counterpart actually
+ * exists. A single match opens directly; multiple matches (e.g. both a Twig and a Qiq template)
+ * are offered in a popup.
+ */
+public class GoToTemplateOrResourceAction extends AnAction {
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent event) {
+        Presentation presentation = event.getPresentation();
+        Project project = event.getProject();
+        VirtualFile file = targetFile(event);
+        if (project == null || file == null || DumbService.isDumb(project)) {
+            presentation.setEnabledAndVisible(false);
+            return;
+        }
+        Resolution resolution = resolve(file, project);
+        if (resolution == null) {
+            presentation.setEnabledAndVisible(false);
+            return;
+        }
+        presentation.setText(resolution.actionText());
+        presentation.setEnabledAndVisible(true);
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        Project project = event.getProject();
+        VirtualFile file = targetFile(event);
+        if (project == null || file == null || DumbService.isDumb(project)) {
+            return;
+        }
+        Resolution resolution = resolve(file, project);
+        if (resolution == null) {
+            return;
+        }
+        PsiElement[] targets = resolution.targets();
+        if (targets.length == 1) {
+            NavigationUtil.activateFileWithPsiElement(targets[0], true);
+            return;
+        }
+        JBPopup popup = NavigationUtil.getPsiElementPopup(targets, resolution.popupTitle());
+        Editor editor = event.getData(CommonDataKeys.EDITOR);
+        if (editor != null) {
+            popup.showInBestPositionFor(editor);
+        } else {
+            popup.showInBestPositionFor(event.getDataContext());
+        }
+    }
+
+    /**
+     * The single selected file, or {@code null}. Falls back from {@code VIRTUAL_FILE} to the
+     * containing file of {@code PSI_FILE} (the Project View does not always provide the former),
+     * and rejects directories and multi-file selections so the action stays unambiguous.
+     */
+    @Nullable
+    private static VirtualFile targetFile(@NotNull AnActionEvent event) {
+        VirtualFile[] selection = event.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY);
+        if (selection != null && selection.length > 1) {
+            return null;
+        }
+        VirtualFile file = event.getData(CommonDataKeys.VIRTUAL_FILE);
+        if (file == null) {
+            PsiFile psiFile = event.getData(CommonDataKeys.PSI_FILE);
+            file = psiFile == null ? null : psiFile.getVirtualFile();
+        }
+        return file == null || file.isDirectory() ? null : file;
+    }
+
+    @Nullable
+    static Resolution resolve(@NotNull VirtualFile file, @NotNull Project project) {
+        String path = file.getPath();
+        if (path.endsWith(".php") && path.contains(TemplateUtils.RESOURCE_DIR_SEGMENT)) {
+            return resolveTemplates(file, project);
+        }
+        return resolveResource(file, project);
+    }
+
+    @Nullable
+    private static Resolution resolveTemplates(@NotNull VirtualFile resourceFile, @NotNull Project project) {
+        PhpClass resourceClass = TemplateUtils.findClass(project, resourceFile);
+        if (resourceClass == null) {
+            return null;
+        }
+        // A resource class gives no hint which engine renders it, so collect every engine's templates.
+        PsiManager psiManager = PsiManager.getInstance(project);
+        List<PsiElement> targets = new ArrayList<>();
+        for (TemplateEngineSupport support : TemplateEngineSupport.SUPPORTS) {
+            for (VirtualFile template : support.resolveTemplates(resourceClass)) {
+                PsiFile psiFile = psiManager.findFile(template);
+                if (psiFile != null) {
+                    targets.add(psiFile);
+                }
+            }
+        }
+        return targets.isEmpty()
+                ? null
+                : new Resolution(BearSundayBundle.message("action.goto.template.open"),
+                        BearSundayBundle.message("action.goto.popup.templates"),
+                        targets.toArray(PsiElement.EMPTY_ARRAY));
+    }
+
+    @Nullable
+    private static Resolution resolveResource(@NotNull VirtualFile templateFile, @NotNull Project project) {
+        TemplateEngineSupport support = TemplateEngineSupport.forFile(templateFile, project);
+        if (support == null) {
+            return null;
+        }
+        PhpClass resourceClass = support.resolveResourceClass(templateFile, project);
+        if (resourceClass == null) {
+            return null;
+        }
+        return new Resolution(BearSundayBundle.message("action.goto.resource.open"),
+                BearSundayBundle.message("action.goto.popup.resources"),
+                new PsiElement[]{resourceClass});
+    }
+
+    record Resolution(@NotNull String actionText, @NotNull String popupTitle, PsiElement @NotNull [] targets) {
+    }
+}

--- a/src/main/java/idea/bear/sunday/template/TemplateEngineSupport.java
+++ b/src/main/java/idea/bear/sunday/template/TemplateEngineSupport.java
@@ -22,9 +22,11 @@ public interface TemplateEngineSupport {
     @Nullable
     String extractVariableName(@NotNull PsiElement element);
 
+    List<TemplateEngineSupport> SUPPORTS = List.of(TwigSupport.INSTANCE, QiqSupport.INSTANCE);
+
     @Nullable
     static TemplateEngineSupport forFile(@NotNull VirtualFile file, @NotNull Project project) {
-        for (TemplateEngineSupport support : List.of(TwigSupport.INSTANCE, QiqSupport.INSTANCE)) {
+        for (TemplateEngineSupport support : SUPPORTS) {
             if (support.accepts(file, project)) {
                 return support;
             }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,8 @@
     <li>BEAR.Resource goto from URIs such as <code>app://self/user</code> to <code>src/Resource/App/User.php</code></li>
     <li>BEAR.Resource JSON Schema goto</li>
     <li>Incoming Link/Embed relation gutter for BEAR.Resource methods</li>
+    <li><code>#[Embed]</code> template navigation: Cmd+click a Twig/Qiq variable to open the embedded template</li>
+    <li>BEAR.Resource &harr; template navigation: jump between a resource class and its Twig/Qiq template from the context menu</li>
     <li>Extract BEAR.Resource parameters to Ray.InputQuery DTO</li>
     <li>Ray.Aop bound interceptor gutter icon and navigation from attributes such as <code>#[Transactional]</code></li>
     <li>Ray.MediaQuery SQL goto</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -83,6 +83,15 @@
       <add-to-group group-id="EditorPopupMenu" anchor="last"/>
       <add-to-group group-id="GoToMenu" anchor="last"/>
     </action>
+
+    <action id="idea.bear.sunday.template.GoToTemplateOrResource"
+            class="idea.bear.sunday.template.GoToTemplateOrResourceAction"
+            text="Go to Related Template or Resource"
+            description="Navigate between a BEAR.Resource class and its template (Twig/Qiq)"
+            icon="/icons/bear.png">
+      <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+      <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+    </action>
   </actions>
 
 </idea-plugin>

--- a/src/main/resources/messages/BearSundayBundle.properties
+++ b/src/main/resources/messages/BearSundayBundle.properties
@@ -22,3 +22,7 @@ input.unsupported.variadic=variadic parameters are not supported
 input.unsupported.input.file=InputFile parameters are already mapped
 input.unsupported.input=Input parameters are already mapped
 input.unsupported.generic=unsupported parameter
+action.goto.template.open=Open Template
+action.goto.resource.open=Open Resource
+action.goto.popup.templates=Templates
+action.goto.popup.resources=Resources

--- a/src/main/resources/messages/BearSundayBundle_ja.properties
+++ b/src/main/resources/messages/BearSundayBundle_ja.properties
@@ -22,3 +22,7 @@ input.unsupported.variadic=可変長引数は未対応です
 input.unsupported.input.file=InputFile引数は既にマップされています
 input.unsupported.input=Input引数は既にマップされています
 input.unsupported.generic=未対応の引数です
+action.goto.template.open=テンプレートを開く
+action.goto.resource.open=リソースを開く
+action.goto.popup.templates=テンプレート
+action.goto.popup.resources=リソース

--- a/src/test/java/idea/bear/sunday/template/GoToTemplateOrResourceActionTest.java
+++ b/src/test/java/idea/bear/sunday/template/GoToTemplateOrResourceActionTest.java
@@ -1,0 +1,88 @@
+package idea.bear.sunday.template;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
+
+public class GoToTemplateOrResourceActionTest extends BasePlatformTestCase {
+
+    public void testTwigResourceResolvesToTemplate() {
+        VirtualFile resource = addFile("src/Resource/Page/Index.php",
+            "<?php\nnamespace MyVendor\\App\\Resource\\Page;\nclass Index {}\n");
+        addFile("var/templates/Page/Index.html.twig", "{{ greeting }}\n");
+
+        GoToTemplateOrResourceAction.Resolution resolution =
+            GoToTemplateOrResourceAction.resolve(resource, getProject());
+
+        assertNotNull(resolution);
+        assertEquals("Open Template", resolution.actionText());
+        assertEquals(1, resolution.targets().length);
+        assertEquals("Index.html.twig", asPsiFile(resolution.targets()[0]).getName());
+    }
+
+    public void testTwigTemplateResolvesToResource() {
+        addFile("src/Resource/Page/Index.php",
+            "<?php\nnamespace MyVendor\\App\\Resource\\Page;\nclass Index {}\n");
+        VirtualFile template = addFile("var/templates/Page/Index.html.twig", "{{ greeting }}\n");
+
+        GoToTemplateOrResourceAction.Resolution resolution =
+            GoToTemplateOrResourceAction.resolve(template, getProject());
+
+        assertNotNull(resolution);
+        assertEquals("Open Resource", resolution.actionText());
+        assertEquals(1, resolution.targets().length);
+        assertEquals("Index", assertInstanceOf(resolution.targets()[0], PhpClass.class).getName());
+    }
+
+    public void testQiqResourceResolvesToTemplate() {
+        VirtualFile resource = addFile("src/Resource/Page/User.php",
+            "<?php\nnamespace MyVendor\\App\\Resource\\Page;\nclass User {}\n");
+        addFile("templates/Page/User.php", "{{= $this->name }}\n");
+
+        GoToTemplateOrResourceAction.Resolution resolution =
+            GoToTemplateOrResourceAction.resolve(resource, getProject());
+
+        assertNotNull(resolution);
+        assertEquals("Open Template", resolution.actionText());
+        assertEquals(1, resolution.targets().length);
+        assertEquals("User.php", asPsiFile(resolution.targets()[0]).getName());
+    }
+
+    public void testQiqTemplateResolvesToResource() {
+        addFile("src/Resource/Page/User.php",
+            "<?php\nnamespace MyVendor\\App\\Resource\\Page;\nclass User {}\n");
+        VirtualFile template = addFile("templates/Page/User.php", "{{= $this->name }}\n");
+
+        GoToTemplateOrResourceAction.Resolution resolution =
+            GoToTemplateOrResourceAction.resolve(template, getProject());
+
+        assertNotNull(resolution);
+        assertEquals("Open Resource", resolution.actionText());
+        assertEquals(1, resolution.targets().length);
+        assertEquals("User", assertInstanceOf(resolution.targets()[0], PhpClass.class).getName());
+    }
+
+    public void testResourceWithoutTemplateResolvesToNull() {
+        VirtualFile resource = addFile("src/Resource/Page/Orphan.php",
+            "<?php\nnamespace MyVendor\\App\\Resource\\Page;\nclass Orphan {}\n");
+
+        assertNull(GoToTemplateOrResourceAction.resolve(resource, getProject()));
+    }
+
+    public void testUnrelatedPhpResolvesToNull() {
+        VirtualFile unrelated = addFile("var/lib/Helper.php",
+            "<?php\nnamespace MyVendor\\App\\Lib;\nclass Helper {}\n");
+
+        assertNull(GoToTemplateOrResourceAction.resolve(unrelated, getProject()));
+    }
+
+    private VirtualFile addFile(String path, String content) {
+        return myFixture.addFileToProject(path, content).getVirtualFile();
+    }
+
+    private PsiFile asPsiFile(PsiElement element) {
+        return assertInstanceOf(element, PsiFile.class);
+    }
+}


### PR DESCRIPTION
## 概要

BEAR.Resource クラスと Twig/Qiq テンプレートを、右クリックメニューから相互にジャンプできます。

- リソース上 → **Open Template**
- テンプレート上 → **Open Resource**

エディタ・Project View のどちらからも使えます。

あわせて、PR #18 で漏れていた `#[Embed]` テンプレートナビゲーションの説明を README / plugin description / CHANGELOG に追記しました。

## 検証

- `./gradlew test`
- `./gradlew runIdeWithQiq`（`Madapaja.TwigModule` で実機確認）

---

> 🤖 本 PR は **Claude Opus 4.8** による実装です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * リソースクラスとそのテンプレート間をコンテキストメニューから行き来できるナビゲーション機能を追加しました。
  * `#[Embed]`テンプレートをCmd+クリックで直接開く機能を追加しました。
  * 複数の候補がある場合、ポップアップメニューで選択できるようになりました。

* **Tests**
  * 新しいテストクラスを追加し、テンプレート/リソース間のナビゲーション機能を検証するテストケースを実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->